### PR TITLE
Split planner into modules

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # ai-fitness-planner
 AI-powered 7-day clean eating and fitness planner
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Copy `.env.sample` to `.env` and add your OpenAI API key:
+   ```bash
+   cp .env.sample .env
+   # then edit .env and set OPENAI_API_KEY
+   ```
+
+3. Run the planner:
+   ```bash
+   python main.py
+   ```

--- a/core.py
+++ b/core.py
@@ -1,0 +1,26 @@
+import os
+from dotenv import load_dotenv
+import openai
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+if not openai.api_key:
+    raise RuntimeError("OPENAI_API_KEY environment variable is not set.")
+
+def get_plan(goal: str) -> str:
+    """Return a 7-day meal and workout plan for the given goal."""
+    system_msg = "You are an AI fitness planner."
+    user_msg = (
+        "Create a 7-day meal plan and workout schedule for the following goal: "
+        f"{goal}. Provide the plan in a clear, organized format with each day labeled."
+    )
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": system_msg},
+            {"role": "user", "content": user_msg},
+        ],
+        temperature=0.7,
+    )
+    return response.choices[0].message.content.strip()

--- a/io.py
+++ b/io.py
@@ -1,0 +1,9 @@
+def ask_user_goal() -> str:
+    """Prompt the user for their fitness goal."""
+    return input("What is your fitness goal? (e.g., lose weight, build muscle) ")
+
+
+def print_plan(plan: str) -> None:
+    """Display the generated plan."""
+    print("\n7-Day Meal and Workout Plan:\n")
+    print(plan)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+import io as io_module
+from core import get_plan
+
+
+def main():
+    goal = io_module.ask_user_goal()
+    plan = get_plan(goal)
+    io_module.print_plan(plan)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- split planner functionality across `core.py`, `io.py`, and `main.py`
- load API key from `.env` inside `core.get_plan`
- document setup using `requirements.txt` and sample `.env`
- add `requirements.txt` and `.env.sample`
- remove old `planner.py`

## Testing
- `python3 -m py_compile core.py io.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684daac001dc832d80153d03c0e888b4