### PR TITLE
Update to OpenAI client-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ AI-powered 7-day clean eating and fitness planner
 
 ## Setup
 
-1. Install dependencies:
+1. Install dependencies (the project now uses `openai>=1.0`):
    ```bash
    pip install -r requirements.txt
    ```
@@ -18,3 +18,5 @@ AI-powered 7-day clean eating and fitness planner
    ```bash
    python main.py
    ```
+
+The code uses the client-based API introduced in `openai>=1.0`.

--- a/core.py
+++ b/core.py
@@ -3,9 +3,10 @@ from dotenv import load_dotenv
 import openai
 
 load_dotenv()
-openai.api_key = os.getenv("OPENAI_API_KEY")
-if not openai.api_key:
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
     raise RuntimeError("OPENAI_API_KEY environment variable is not set.")
+client = openai.OpenAI(api_key=api_key)
 
 def get_plan(goal: str) -> str:
     """Return a 7-day meal and workout plan for the given goal."""
@@ -15,7 +16,7 @@ def get_plan(goal: str) -> str:
         f"{goal}. Provide the plan in a clear, organized format with each day labeled."
     )
 
-    response = openai.ChatCompletion.create(
+    response = client.chat.completions.create(
         model="gpt-4",
         messages=[
             {"role": "system", "content": system_msg},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-openai
+openai>=1.0
 python-dotenv


### PR DESCRIPTION
## Summary
- use `openai.OpenAI` client instead of global API key
- update `requirements.txt` to require `openai>=1.0`
- mention the library change in the README

## Testing
- `python -m py_compile core.py main.py user_io.py`


------
https://chatgpt.com/codex/tasks/task_e_684db30e5c1c832db55fdc1c84232b34