### PR TITLE
Fix import errors in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,5 @@
 import io_utils as io_module
-import io as io_module
-
-import user_io
+from core import get_plan
 
 def main():
 


### PR DESCRIPTION
## Summary
- fix `main.py` imports so we don't overwrite `io_utils`
- import `get_plan` from `core`

## Testing
- `python -m py_compile main.py io_utils.py user_io.py core.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_684dbefcae18832d9662dfed23dd703e