### PR TITLE
Add Thai Gradio interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,47 +3,57 @@ from core import get_plan
 from io_utils import export_plan
 import tempfile
 
-
-def generate_plan(goal, custom_goal):
-    actual_goal = custom_goal if goal == "Custom" else goal
-    if not actual_goal:
-        raise gr.Error("Please provide a fitness goal.")
-    plan = get_plan(actual_goal)
-    return plan
-
-
-def download_plan(plan_text):
-    if not plan_text:
-        raise gr.Error("No plan to download. Generate one first.")
-    temp = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
-    temp.close()
-    export_plan(plan_text, temp.name, "txt")
-    return temp.name
+# Preset goals in Thai
+PRESET_GOALS = [
+    "ลดน้ำหนัก 3 กิโลใน 30 วัน",
+    "ลดพุงและกระชับแขนขา",
+    "เพิ่มกล้ามเนื้อแบบ lean",
+    "กำหนดเอง",
+]
 
 
-def toggle_custom(goal):
-    return gr.update(visible=goal == "Custom")
+def generate_plan(selected_goal: str, custom_goal: str) -> str:
+    """Generate plan based on selected or custom goal."""
+    goal = custom_goal if selected_goal == "กำหนดเอง" else selected_goal
+    if not goal.strip():
+        raise gr.Error("กรุณาใส่เป้าหมายก่อน")
+    return get_plan(goal)
+
+
+def save_plan(plan_text: str) -> str:
+    """Save the plan to a temporary txt file and return the path."""
+    if not plan_text.strip():
+        raise gr.Error("ยังไม่มีแผน กรุณาสร้างแผนก่อน")
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".txt")
+    tmp.close()
+    export_plan(plan_text, tmp.name, "txt")
+    return tmp.name
+
+
+def toggle_custom(goal: str):
+    """Show custom textbox only when 'กำหนดเอง' is selected."""
+    return gr.update(visible=goal == "กำหนดเอง")
 
 
 with gr.Blocks(css=".container {max-width: 700px; margin: auto;}") as demo:
     gr.Markdown("# AI Fitness Planner", elem_classes="container")
 
     with gr.Column(elem_classes="container"):
-        goal_dropdown = gr.Dropdown(
-            ["Lose 3 kg in 30 days", "Tone arms and legs", "Gain muscle mass", "Custom"],
-            label="Select your goal",
-            value="Lose 3 kg in 30 days",
+        goal_dd = gr.Dropdown(
+            PRESET_GOALS,
+            value=PRESET_GOALS[0],
+            label="เลือกเป้าหมาย",
         )
-        custom_input = gr.Textbox(label="Custom goal", visible=False)
-        goal_dropdown.change(toggle_custom, goal_dropdown, custom_input)
+        custom_tb = gr.Textbox(label="ระบุเป้าหมาย", visible=False)
+        goal_dd.change(toggle_custom, goal_dd, custom_tb)
 
-        generate_btn = gr.Button("Generate Plan")
-        plan_output = gr.Textbox(label="Plan", lines=15, interactive=False)
-        download_btn = gr.Button("Download Plan")
-        file_output = gr.File(label="Download", interactive=False)
+        gen_btn = gr.Button("สร้างแผน")
+        plan_box = gr.Textbox(label="แผน 7 วัน", lines=20, interactive=False)
+        save_btn = gr.Button("บันทึกแผน")
+        download_file = gr.File(label="ดาวน์โหลดไฟล์", interactive=False)
 
-        generate_btn.click(generate_plan, [goal_dropdown, custom_input], plan_output)
-        download_btn.click(download_plan, plan_output, file_output)
+        gen_btn.click(generate_plan, [goal_dd, custom_tb], plan_box)
+        save_btn.click(save_plan, plan_box, download_file)
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
## Summary
- create a Gradio web UI for preset Thai fitness goals
- allow custom goal input when "กำหนดเอง" is chosen
- add option to download the generated plan

## Testing
- `python -m py_compile app.py core.py io_utils.py main.py user_io.py`


------
https://chatgpt.com/codex/tasks/task_e_684dc11834ac832db7ea6a2004fa89c6