### PR TITLE
Detect goal language automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Fitness Planner
 
-A command line and web application that generates a **7‑day meal and workout plan** using OpenAI. When your goal is written in Thai the response will also be in Thai.
+A command line and web application that generates a **7‑day meal and workout plan** using OpenAI. The planner automatically detects whether your goal is written in Thai or English using the `langdetect` library and responds in the same language.
 
 ## Setup
 

--- a/core.py
+++ b/core.py
@@ -1,6 +1,10 @@
 import os
 from dotenv import load_dotenv
 import openai
+from langdetect import detect, DetectorFactory, LangDetectException
+
+# ensure deterministic language detection results
+DetectorFactory.seed = 0
 
 # use the client-based API from openai>=1.0
 from openai import OpenAI
@@ -21,9 +25,17 @@ def _is_thai(text: str) -> bool:
             return True
     return False
 
+
+def _goal_is_thai(text: str) -> bool:
+    """Return True if the text language is detected as Thai."""
+    try:
+        return detect(text) == "th"
+    except LangDetectException:
+        return _is_thai(text)
+
 def get_plan(goal: str) -> str:
     """Return a 7-day meal and workout plan for the given goal."""
-    thai = _is_thai(goal)
+    thai = _goal_is_thai(goal)
     system_msg = "You are an AI fitness planner."
     system_msg += " Respond in Thai." if thai else " Respond in English."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ python-dotenv
 gradio
 openai>=1.0
 python-dotenv
+langdetect
 


### PR DESCRIPTION
## Summary
- detect language of `goal` using `langdetect`
- note the new language detection feature in README
- include `langdetect` in requirements

## Testing
- `python -m py_compile app.py core.py io_utils.py main.py user_io.py`

------
https://chatgpt.com/codex/tasks/task_e_684dc2fae8c0832d81f58b2f9f03a550