### PR TITLE
Fix import error in frontend

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,6 +1,10 @@
 import os
 import requests
 import gradio as gr
+import sys
+
+# allow importing modules from the repository root when running this file
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from io_utils import export_plan
 


### PR DESCRIPTION
## Summary
- modify `frontend/app.py` to add the repository root to `sys.path`

## Testing
- `python -m py_compile frontend/app.py`
- `python -m py_compile backend/main.py backend/core.py io_utils.py main.py user_io.py`

------
https://chatgpt.com/codex/tasks/task_e_684dc62536d8832d928130c80f8af8cf