### PR TITLE
Add plan evaluation and enhanced Gradio UI

### DIFF
--- a/backend/core.py
+++ b/backend/core.py
@@ -55,3 +55,25 @@ def get_plan(goal: str) -> str:
         temperature=0.7,
     )
     return response.choices[0].message.content.strip()
+
+
+def evaluate_plan(goal: str, plan: str) -> str:
+    """Return short feedback evaluating the given plan."""
+    thai = _goal_is_thai(goal)
+    system_msg = "You are a fitness coach providing short feedback on a 7-day plan."
+    system_msg += " Respond in Thai." if thai else " Respond in English."
+
+    user_msg = (
+        f"Goal: {goal}\n\nPlan:\n{plan}\n\n"
+        "Give 3 sentences of feedback about whether the plan is realistic, too intense, or unbalanced."
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": system_msg},
+            {"role": "user", "content": user_msg},
+        ],
+        temperature=0.7,
+    )
+    return response.choices[0].message.content.strip()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from .core import get_plan
+from .core import get_plan, evaluate_plan
 
 app = FastAPI()
 
@@ -17,6 +17,11 @@ app.add_middleware(
 class GoalRequest(BaseModel):
     goal: str
 
+
+class EvaluateRequest(BaseModel):
+    goal: str
+    plan: str
+
 @app.post("/generate")
 async def generate(req: GoalRequest):
     try:
@@ -24,4 +29,13 @@ async def generate(req: GoalRequest):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     return {"plan": plan}
+
+
+@app.post("/evaluate")
+async def evaluate(req: EvaluateRequest):
+    try:
+        feedback = evaluate_plan(req.goal, req.plan)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"feedback": feedback}
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -2,6 +2,7 @@ import os
 import requests
 import gradio as gr
 import sys
+import re
 
 # allow importing modules from the repository root when running this file
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -10,22 +11,41 @@ from io_utils import export_plan
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
-PRESET_GOALS = [
+GOAL_OPTIONS = [
     "ลดน้ำหนัก 3 กิโลใน 30 วัน",
     "ลดพุงและกระชับแขนขา",
     "เพิ่มกล้ามเนื้อแบบ lean",
-    "กำหนดเอง",
+    "อยากฟิตให้ทันวันแต่งงาน",
 ]
 
 
-def generate_plan(selected_goal: str, custom_goal: str) -> str:
-    goal = custom_goal if selected_goal == "กำหนดเอง" else selected_goal
+def _calc_avg_kcal(text: str):
+    numbers = re.findall(r"(\d+(?:\.\d+)?)\s*k(?:c|C)al", text)
+    if not numbers:
+        return None
+    total = sum(float(n) for n in numbers)
+    return round(total / len(numbers))
+
+
+def generate_plan(goal: str):
     if not goal.strip():
         raise gr.Error("กรุณาใส่เป้าหมายก่อน")
     resp = requests.post(f"{BACKEND_URL}/generate", json={"goal": goal})
     if resp.status_code != 200:
         raise gr.Error(f"Error: {resp.text}")
-    return resp.json()["plan"]
+    plan = resp.json()["plan"]
+
+    eval_resp = requests.post(
+        f"{BACKEND_URL}/evaluate", json={"goal": goal, "plan": plan}
+    )
+    if eval_resp.status_code != 200:
+        raise gr.Error(f"Error: {eval_resp.text}")
+    feedback = eval_resp.json()["feedback"]
+
+    avg = _calc_avg_kcal(plan)
+    kcal_text = f"📊 ค่าเฉลี่ยแคลอรี่ต่อวัน: {avg} kcal" if avg else ""
+    kcal_update = gr.update(value=kcal_text, visible=bool(kcal_text))
+    return plan, feedback, kcal_update
 
 
 def save_plan(plan_text: str) -> str:
@@ -39,25 +59,37 @@ def save_plan(plan_text: str) -> str:
     return tmp.name
 
 
-def toggle_custom(goal: str):
-    return gr.update(visible=goal == "กำหนดเอง")
-
-
 with gr.Blocks(css=".container {max-width: 700px; margin: auto;}") as demo:
     gr.Markdown("# AI Fitness Planner", elem_classes="container")
 
     with gr.Column(elem_classes="container"):
-        goal_dd = gr.Dropdown(PRESET_GOALS, value=PRESET_GOALS[0], label="เลือกเป้าหมาย")
-        custom_tb = gr.Textbox(label="ระบุเป้าหมาย", visible=False)
-        goal_dd.change(toggle_custom, goal_dd, custom_tb)
+        goal_tb = gr.Textbox(label="เป้าหมายของคุณ")
+        with gr.Row():
+            b1 = gr.Button(GOAL_OPTIONS[0])
+            b2 = gr.Button(GOAL_OPTIONS[1])
+        with gr.Row():
+            b3 = gr.Button(GOAL_OPTIONS[2])
+            b4 = gr.Button(GOAL_OPTIONS[3])
+
+        b1.click(lambda: gr.update(value=GOAL_OPTIONS[0]), None, goal_tb, queue=False)
+        b2.click(lambda: gr.update(value=GOAL_OPTIONS[1]), None, goal_tb, queue=False)
+        b3.click(lambda: gr.update(value=GOAL_OPTIONS[2]), None, goal_tb, queue=False)
+        b4.click(lambda: gr.update(value=GOAL_OPTIONS[3]), None, goal_tb, queue=False)
 
         gen_btn = gr.Button("สร้างแผน")
         plan_box = gr.Textbox(label="แผน 7 วัน", lines=20, interactive=False)
+        kcal_md = gr.Markdown(visible=False)
+        with gr.Accordion("🧠 ความเห็นจากโค้ช AI", open=False) as acc:
+            feedback_md = gr.Markdown()
+
+        copy_btn = gr.Button("📤 คัดลอกแผนเพื่อส่งต่อใน LINE")
         save_btn = gr.Button("บันทึกแผน")
         download_file = gr.File(label="ดาวน์โหลดไฟล์", interactive=False)
 
-        gen_btn.click(generate_plan, [goal_dd, custom_tb], plan_box)
+        gen_btn.click(generate_plan, [goal_tb], [plan_box, feedback_md, kcal_md])
         save_btn.click(save_plan, plan_box, download_file)
+        copy_btn.click(None, plan_box, None, _js="(text) => navigator.clipboard.writeText(text)")
+
 
 if __name__ == "__main__":
     demo.launch()


### PR DESCRIPTION
## Summary
- add `evaluate_plan` helper for AI plan feedback
- expose new `/evaluate` endpoint
- modernize frontend with text goal input, quick-select buttons and AI feedback
- add copy-to-clipboard and calorie summary features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dc7c4a0b0832d8bcf78c93630c054